### PR TITLE
Formatting issue with start time

### DIFF
--- a/src/PagerEvent.js
+++ b/src/PagerEvent.js
@@ -29,7 +29,7 @@ const PagerEvent = ({ event, stripe }) => {
     >
       <div id="ev_head">
         <span className="SUF">
-          Start :{startTime ? startTime : 'Unknown'} -{' '}
+          Start: {startTime ? startTime : 'Unknown'} -{' '}
           <span style={{ backgroundColor: '#f00' }}>{eventId}</span>-{' '}
           {agency(responseRequired)}
         </span>


### PR DESCRIPTION
Fixed formatting with an issue with "Start: " being shown as "Start :"m on each pager message.